### PR TITLE
Fix DEFER macro

### DIFF
--- a/defer.h
+++ b/defer.h
@@ -55,9 +55,13 @@ template <typename F> detail::defer_raii<F> defer(F &&f)
   return {std::forward<F>(f)};
 }
 
+#define DEFER_ACTUALLY_JOIN(x, y) x##y
+#define DEFER_JOIN(x, y) DEFER_ACTUALLY_JOIN(x, y)
 #ifdef __COUNTER__
-#define DEFER(lambda__) const auto &defer_object_##__COUNTER__ = ext::defer([&]() lambda__)
+  #define DEFER_UNIQUE_VARNAME(x) DEFER_JOIN(x, __COUNTER__)
 #else
-#define DEFER(lambda__) const auto &defer_object_##__LINE__ = ext::defer([&]() lambda__)
+  #define DEFER_UNIQUE_VARNAME(x) DEFER_JOIN(x, __LINE__)
 #endif
+
+#define DEFER(lambda__) [[maybe_unused]] const auto& DEFER_UNIQUE_VARNAME(defer_object) = ext::defer([&]() lambda__)
 }  // namespace ext


### PR DESCRIPTION
Fixes ` error: redefinition of 'defer_object___COUNTER__'` if two DEFER were used in the same function (since `__COUNTER__` wasn't being replaced) and also `warning: unused variable 'defer_object___COUNTER__' ` (uses C++17 `[[maybe_unused]]`).

The macro shenanigans are to make `__COUNTER__` be replaced.